### PR TITLE
Add multi-module configuration support and fix form alignment

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ideaVersion="2016.2"
+ideaVersion="2017.1.3"
 if [ ! -d ./idea-IC ]; then
 # Get our IDEA dependency
 if [ -f ~/Tools/ideaIC-${ideaVersion}.tar.gz ];

--- a/embeddedlinux-jvmdebugger.iml
+++ b/embeddedlinux-jvmdebugger.iml
@@ -9,7 +9,7 @@
       <sourceFolder url="file://$MODULE_DIR$/Resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
     </content>
-    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-145.1617.8" jdkType="IDEA JDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="lombok" level="project" />
     <orderEntry type="library" name="bcprov-ext-jdk15on-1.47" level="project" />

--- a/src/com/atsebak/embeddedlinuxjvm/commandline/AppCommandLineState.java
+++ b/src/com/atsebak/embeddedlinuxjvm/commandline/AppCommandLineState.java
@@ -42,7 +42,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
-import com.intellij.util.NotNullFunction;
 import com.intellij.util.PathsList;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -217,6 +216,7 @@ public class AppCommandLineState extends JavaCommandLineState {
         // setting jvm config
         javaParams.getProgramParametersList().add(configuration.getRunnerParameters().getProgramArguments());
         javaParams.getVMParametersList().add(configuration.getRunnerParameters().getVmParameters());
+        javaParams.setModuleName(configuration.getRunnerParameters().getModuleName());
         javaParams.setMainClass(configuration.getRunnerParameters().getMainclass());
         javaParams.setWorkingDirectory(project.getBasePath());
         javaParams.getProgramParametersList().addParametersString(configuration.getOutputFilePath());

--- a/src/com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle.properties
+++ b/src/com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle.properties
@@ -39,3 +39,5 @@ pi.invalid.key=Invalid SSH Private Key File Entered
 basepackage.invalid=Base package is invalid
 bbb.project.description=Basic BeagleBone Black Project Template
 pi.invalid.sshport=Invalid SSH Port entered
+app.module=Module
+app.mainclass=Main Class

--- a/src/com/atsebak/embeddedlinuxjvm/runner/data/EmbeddedLinuxJVMRunConfigurationRunnerParameters.java
+++ b/src/com/atsebak/embeddedlinuxjvm/runner/data/EmbeddedLinuxJVMRunConfigurationRunnerParameters.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Data
 public class EmbeddedLinuxJVMRunConfigurationRunnerParameters implements Cloneable {
+	public String moduleName;
     public String mainclass;
     private String hostname;
     private boolean runAsRoot;

--- a/src/com/atsebak/embeddedlinuxjvm/ui/RunConfigurationEditor.form
+++ b/src/com/atsebak/embeddedlinuxjvm/ui/RunConfigurationEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.atsebak.embeddedlinuxjvm.ui.RunConfigurationEditor">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="13" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="751" height="523"/>
@@ -8,104 +8,11 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="6bda6" binding="myGenericPanel" layout-manager="GridLayoutManager" row-count="8" column-count="8" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="7" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="d4bb4" class="com.intellij.openapi.ui.LabeledComponent" binding="myMainClass" custom-create="true">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="8" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="-1" height="20"/>
-              </grid>
-            </constraints>
-            <properties>
-              <labelLocation value="West"/>
-              <text resource-bundle="messages/ExecutionBundle" key="application.configuration.main.class.label"/>
-            </properties>
-          </component>
-          <component id="ac4fc" class="com.intellij.openapi.ui.LabeledComponent" binding="myModule">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="8" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <componentClass value="javax.swing.JComboBox"/>
-              <labelLocation value="West"/>
-              <text resource-bundle="messages/ExecutionBundle" key="application.configuration.use.classpath.and.jdk.of.module.label"/>
-              <visible value="false"/>
-            </properties>
-          </component>
-          <vspacer id="46a07">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="8" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-                <preferred-size width="-1" height="10"/>
-              </grid>
-            </constraints>
-          </vspacer>
-          <vspacer id="e41af">
-            <constraints>
-              <grid row="6" column="0" row-span="1" col-span="8" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-                <preferred-size width="-1" height="10"/>
-              </grid>
-            </constraints>
-          </vspacer>
-          <vspacer id="a3e4">
-            <constraints>
-              <grid row="1" column="1" row-span="1" col-span="7" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </vspacer>
-          <component id="9f70b" class="javax.swing.JButton" binding="validateConnection">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="pi.validationconection"/>
-            </properties>
-          </component>
-          <component id="71922" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="VM options:"/>
-            </properties>
-          </component>
-          <component id="bb6fa" class="com.intellij.ui.RawCommandLineEditor" binding="vmParameters">
-            <constraints>
-              <grid row="5" column="3" row-span="1" col-span="5" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="a0b00" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Program Arguments:"/>
-            </properties>
-          </component>
-          <component id="831f7" class="com.intellij.ui.RawCommandLineEditor" binding="programArguments">
-            <constraints>
-              <grid row="7" column="3" row-span="1" col-span="5" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="78ee8" class="javax.swing.JLabel" binding="sshStatus">
-            <constraints>
-              <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value=""/>
-            </properties>
-          </component>
-        </children>
-      </grid>
       <component id="3f3eb" class="javax.swing.JLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="16"/>
+          </grid>
         </constraints>
         <properties>
           <labelFor value="c60bd"/>
@@ -114,7 +21,9 @@
       </component>
       <component id="60c26" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="16"/>
+          </grid>
         </constraints>
         <properties>
           <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="pi.port"/>
@@ -122,7 +31,9 @@
       </component>
       <component id="137e5" class="javax.swing.JCheckBox" binding="runAsRootCheckBox" default-binding="true">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="20"/>
+          </grid>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -131,7 +42,7 @@
       </component>
       <component id="54499" class="javax.swing.JTextField" binding="debugPort">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -139,7 +50,7 @@
       </component>
       <component id="c60bd" class="javax.swing.JTextField" binding="hostName">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -147,7 +58,9 @@
       </component>
       <component id="73a12" class="javax.swing.JLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="16"/>
+          </grid>
         </constraints>
         <properties>
           <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="pi.username"/>
@@ -155,7 +68,7 @@
       </component>
       <component id="ff411" class="javax.swing.JTextField" binding="username">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -163,7 +76,9 @@
       </component>
       <component id="dd5cc" class="javax.swing.JLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="16"/>
+          </grid>
         </constraints>
         <properties>
           <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="pi.password"/>
@@ -171,7 +86,7 @@
       </component>
       <component id="5909c" class="javax.swing.JPasswordField" binding="password">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -179,7 +94,9 @@
       </component>
       <component id="c75f6" class="javax.swing.JCheckBox" binding="usingKey">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="20"/>
+          </grid>
         </constraints>
         <properties>
           <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="ssh.key"/>
@@ -187,7 +104,7 @@
       </component>
       <component id="ae8da" class="javax.swing.JTextField" binding="keyfile">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -195,7 +112,7 @@
       </component>
       <component id="ea0f7" class="javax.swing.JButton" binding="selectPrivateKeyButton" default-binding="true">
         <constraints>
-          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="ssh.select.key"/>
@@ -203,7 +120,9 @@
       </component>
       <component id="87494" class="javax.swing.JLabel">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="16"/>
+          </grid>
         </constraints>
         <properties>
           <text value="SSH Port"/>
@@ -211,12 +130,91 @@
       </component>
       <component id="1a53c" class="javax.swing.JTextField" binding="sshPort">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
         <properties/>
       </component>
+      <component id="ac4fc" class="com.intellij.openapi.ui.LabeledComponent" binding="myModule">
+        <constraints>
+          <grid row="9" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <componentClass value="com.intellij.application.options.ModulesComboBox"/>
+          <labelInsets top="0" left="0" bottom="0" right="78"/>
+          <labelLocation value="West"/>
+          <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="app.module"/>
+          <visible value="true"/>
+        </properties>
+      </component>
+      <component id="d4bb4" class="com.intellij.openapi.ui.LabeledComponent" binding="myMainClass" custom-create="true">
+        <constraints>
+          <grid row="10" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="20"/>
+          </grid>
+        </constraints>
+        <properties>
+          <enabled value="true"/>
+          <labelInsets top="0" left="0" bottom="0" right="78"/>
+          <labelLocation value="West"/>
+          <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="app.mainclass"/>
+        </properties>
+      </component>
+      <component id="71922" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="135" height="16"/>
+          </grid>
+        </constraints>
+        <properties>
+          <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="app.vmoptions"/>
+        </properties>
+      </component>
+      <component id="bb6fa" class="com.intellij.ui.RawCommandLineEditor" binding="vmParameters">
+        <constraints>
+          <grid row="11" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="9f70b" class="javax.swing.JButton" binding="validateConnection">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="pi.validationconection"/>
+        </properties>
+      </component>
+      <component id="78ee8" class="javax.swing.JLabel" binding="sshStatus">
+        <constraints>
+          <grid row="7" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <component id="831f7" class="com.intellij.ui.RawCommandLineEditor" binding="programArguments">
+        <constraints>
+          <grid row="12" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="a0b00" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="com/atsebak/embeddedlinuxjvm/localization/EmbeddedLinuxJVMBundle" key="app.programargs"/>
+        </properties>
+      </component>
+      <vspacer id="aba59">
+        <constraints>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <minimum-size width="-1" height="15"/>
+            <preferred-size width="-1" height="15"/>
+          </grid>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/test/com/atsebak/embeddedlinuxjvm/commandline/CommandLineTargetTest.java
+++ b/test/com/atsebak/embeddedlinuxjvm/commandline/CommandLineTargetTest.java
@@ -24,6 +24,7 @@ public class CommandLineTargetTest {
     @Before
     public void setUp() {
         parameters.setRunAsRoot(true);
+        parameters.setModuleName("mymodule");
         parameters.setMainclass("com.test.Main");
         parameters.setPort("4000");
         parameters.setHostname("127.0.0.1");
@@ -31,6 +32,7 @@ public class CommandLineTargetTest {
         when(javaParameters.getProgramParametersList()).thenReturn(parametersList);
         when(javaParameters.getProgramParametersList().getParameters()).thenReturn(new ArrayList<String>());
         when(javaParameters.getVMParametersList()).thenReturn(jvmParametersList);
+        when(javaParameters.getModuleName()).thenReturn(parameters.getModuleName());
         when(javaParameters.getMainClass()).thenReturn(parameters.getMainclass());
     }
 

--- a/test/com/atsebak/embeddedlinuxjvm/runner/data/EmbeddedLinuxJVMRunnerParametersTest.java
+++ b/test/com/atsebak/embeddedlinuxjvm/runner/data/EmbeddedLinuxJVMRunnerParametersTest.java
@@ -12,6 +12,7 @@ public class EmbeddedLinuxJVMRunnerParametersTest {
         EmbeddedLinuxJVMRunConfigurationRunnerParameters embeddedLinuxJVMRunConfigurationRunnerParameters = new EmbeddedLinuxJVMRunConfigurationRunnerParameters();
         embeddedLinuxJVMRunConfigurationRunnerParameters.setClassesDirectory("/main/target");
         embeddedLinuxJVMRunConfigurationRunnerParameters.setHostname("10.42.0.224");
+        embeddedLinuxJVMRunConfigurationRunnerParameters.setModuleName("mymodule");
         embeddedLinuxJVMRunConfigurationRunnerParameters.setMainclass("com.raspberrypi.Main");
         embeddedLinuxJVMRunConfigurationRunnerParameters.setPort("100");
         embeddedLinuxJVMRunConfigurationRunnerParameters.setPassword("tester");

--- a/test/com/atsebak/embeddedlinuxjvm/runner/data/EmbeddedLinuxJVMRunnerValidatorTest.java
+++ b/test/com/atsebak/embeddedlinuxjvm/runner/data/EmbeddedLinuxJVMRunnerValidatorTest.java
@@ -12,6 +12,7 @@ public class EmbeddedLinuxJVMRunnerValidatorTest {
     public void testCheckPiSettings() {
         piRunnerParameters.setHostname("10.42.0.25");
         piRunnerParameters.setPort("40");
+        piRunnerParameters.setModuleName("mymodule");
         piRunnerParameters.setMainclass("Main");
         piRunnerParameters.setUsername("testuser");
         piRunnerParameters.setPassword("testpasssword");


### PR DESCRIPTION
This fixes the issue that caused conflicts after all libraries have been synchronized on the Pi. I've added a combobox 'Module' in the form that will filter only its libraries to by synchronized, if we keep the combobox empty, it will act as before. I've also fixed the form alignment, if you don't like I could revert and only add the 'Module' combobox.

![rpi-plugin-screenshot](https://user-images.githubusercontent.com/3971064/27869671-a849c198-616e-11e7-8f8b-f20d93b93e85.png)