### PR TITLE
Remove old librairies from target with new build

### DIFF
--- a/src/main/java/com/blocklatency/embeddedlinuxjvm/protocol/ssh/SSHHandlerTarget.java
+++ b/src/main/java/com/blocklatency/embeddedlinuxjvm/protocol/ssh/SSHHandlerTarget.java
@@ -91,6 +91,8 @@ public class SSHHandlerTarget {
                     String.format("mkdir -p %s", FileUtilities.CLASSES),
                     String.format("mkdir -p %s", FileUtilities.LIB),
                     String.format("cd %s", path + FileUtilities.SEPARATOR + FileUtilities.CLASSES),
+                    "rm -rf *",
+                    String.format("cd %s", path + FileUtilities.SEPARATOR + FileUtilities.LIB),
                     "rm -rf *"
             );
             for (String command : commands) {


### PR DESCRIPTION
Hi!

So recently we've begun having this problem when switching between different branches on our projects.
This is the error we get when we are switching between an old stable branch and our master branch :

```
java.lang.Exception: java.lang.NoSuchMethodError
```

We have isolated this problem to the fact that old libraries are not cleaned when uploading a new build. This fix cleans the lib directory on the target like we do with the classes directory. We don't think this fix will have a performance hit since the libs folder is uploaded to the target on every build.